### PR TITLE
fix(content): 한국어 번역 이미지 누락 시 영문 원본 폴백 매핑 (#1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "sync-content": "tsx scripts/sync-content.ts",
     "smoke-test": "tsx scripts/smoke-test.ts"

--- a/scripts/sync-content.ts
+++ b/scripts/sync-content.ts
@@ -105,6 +105,73 @@ async function readKoreanReadme(lessonId: string): Promise<string> {
 }
 
 /**
+ * 한국어 README의 마크다운에서 모든 이미지 src를 추출.
+ * `![alt](path)` + `[![alt](path)](url)` 형태 모두 포착.
+ */
+function extractImagePaths(markdown: string): string[] {
+  const paths: string[] = []
+  for (const m of markdown.matchAll(/!\[[^\]]*\]\(([^)\s]+)/g)) {
+    paths.push(m[1].split('?')[0])
+  }
+  return [...new Set(paths)]
+}
+
+/**
+ * 한국어 번역 이미지 누락 시 영문 원본으로 자동 폴백 매핑을 빌드.
+ *
+ * 한국어 README는 `../../../translated_images/ko/<base>.<hash>.<ext>` 형태로
+ * 이미지를 참조한다. 실제 파일이 source repo에 존재하지 않으면(번역 누락):
+ *  1) `<lesson-id>/images/<base>.<original-ext>` 영문 원본을 찾아 폴백
+ *  2) 어디에도 없으면 콘솔 경고
+ *
+ * 결과: { 원본 src → 폴백 src } 매핑. 모든 이미지가 정상이면 빈 객체.
+ */
+async function buildImageMap(
+  lessonId: string,
+  markdown: string,
+): Promise<{ map: Record<string, string>; missing: string[] }> {
+  const map: Record<string, string> = {}
+  const missing: string[] = []
+  const paths = extractImagePaths(markdown)
+
+  for (const original of paths) {
+    if (/^(https?:|data:|blob:)/.test(original)) continue
+
+    const stripped = original.replace(/^(\.\.\/)+/, '').replace(/^\.\//, '')
+    const absInSource = join(SOURCE_REPO, stripped)
+
+    if (existsSync(absInSource)) continue // OK as-is
+
+    // 폴백 1: translated_images/ko/<base>.<hash>.<ext> → <lesson-id>/images/<base>.*
+    const koMatch = stripped.match(/^translated_images\/ko\/(.+?)(\.[a-f0-9]{16})?\.(webp|png|jpg|jpeg|gif|svg)$/)
+    if (koMatch) {
+      const base = koMatch[1]
+      const lessonImagesDir = join(SOURCE_REPO, lessonId, 'images')
+      if (existsSync(lessonImagesDir)) {
+        const candidates = await readdir(lessonImagesDir)
+        const found = candidates.find(
+          (f) => f.toLowerCase().startsWith(base.toLowerCase() + '.'),
+        )
+        if (found) {
+          map[original] = `${lessonId}/images/${found}`
+          continue
+        }
+      }
+    }
+
+    // 폴백 2: translated_images/<lang>/... → 영문 원본 (lang 다른 경우 대비)
+    const otherLangMatch = stripped.match(/^translated_images\/[^/]+\/(.+)$/)
+    if (otherLangMatch) {
+      // 동일한 이름의 영문 원본을 찾기 어려움 — 마지막으로 콘솔 경고
+    }
+
+    missing.push(original)
+  }
+
+  return { map, missing }
+}
+
+/**
  * Jupyter notebook(.ipynb)에서 Python 코드 셀들을 추출해 단일 .py 표현으로 결합.
  * 마크다운 셀은 # 주석 블록으로 변환해 학습 흐름을 유지.
  */
@@ -224,6 +291,7 @@ async function main() {
   await mkdir(OUTPUT_DIR, { recursive: true })
 
   let okCount = 0
+  let totalMissingImages = 0
   for (const meta of LESSONS) {
     process.stdout.write(`  • ${meta.id}: `)
     const lessonDir = join(SOURCE_REPO, meta.id)
@@ -240,12 +308,16 @@ async function main() {
         hasLessonSpec(meta.id),
       ])
 
+    const { map: imageMap, missing } = await buildImageMap(meta.id, contentMarkdown)
+    totalMissingImages += missing.length
+
     const lesson = {
       ...meta,
       contentMarkdown,
       pythonReference,
       typescriptReference,
       hasVariableSpec,
+      ...(Object.keys(imageMap).length > 0 ? { imageMap } : {}),
     }
 
     await writeFile(
@@ -259,8 +331,16 @@ async function main() {
     if (pythonReference) tags.push('py')
     if (typescriptReference) tags.push('ts')
     if (hasVariableSpec) tags.push('spec')
+    if (Object.keys(imageMap).length > 0) tags.push(`fallback:${Object.keys(imageMap).length}`)
     console.log(`✓ [${tags.join(',') || 'empty'}]`)
+    if (missing.length > 0) {
+      console.warn(`    ⚠ 누락 이미지 ${missing.length}개 (폴백도 실패):`)
+      for (const m of missing) console.warn(`       - ${m}`)
+    }
     okCount += 1
+  }
+  if (totalMissingImages > 0) {
+    console.warn(`\n⚠ 전체 누락 이미지 ${totalMissingImages}개. 깨진 이미지로 노출됩니다.`)
   }
 
   // 인덱스 파일도 함께 작성

--- a/src/components/lesson/LessonContent.tsx
+++ b/src/components/lesson/LessonContent.tsx
@@ -1,6 +1,7 @@
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { CodeBlock } from './CodeBlock'
+import { resolveImageSrc } from '#/lib/image-src'
 
 type SupportedLang = 'python' | 'typescript' | 'javascript' | 'plaintext'
 
@@ -15,26 +16,18 @@ const NORMALIZED_LANGS: Record<string, SupportedLang> = {
   jsx: 'javascript',
 }
 
-const SOURCE_REPO_RAW_BASE =
-  'https://raw.githubusercontent.com/microsoft/generative-ai-for-beginners/main/'
-
-/**
- * 원본 레포의 한국어 README는 이미지를 ../../../translated_images/ko/foo.webp 식으로
- * 참조한다 (translations/ko/<id>/README.md 기준). 우리 페이지는 그 위치가 아니므로
- * 상대 경로를 GitHub raw URL로 다시 앵커링한다. 절대 URL은 그대로 둔다.
- */
-function resolveImageSrc(src: string | undefined): string | undefined {
-  if (!src) return src
-  if (/^(https?:|data:|blob:)/.test(src)) return src
-  const stripped = src.replace(/^(\.\.\/)+/, '').replace(/^\.\//, '')
-  return `${SOURCE_REPO_RAW_BASE}${stripped}`
-}
-
 /**
  * 한국어 마크다운 본문을 렌더링. 코드 펜스는 Shiki로 하이라이팅,
- * 이미지는 원본 레포의 상대 경로를 GitHub raw URL로 변환.
+ * 이미지는 원본 레포의 상대 경로를 GitHub raw URL로 변환. imageMap이
+ * 주어지면 폴백 매핑을 우선 적용한다 (한국어 번역 이미지 누락 대응).
  */
-export function LessonContent({ markdown }: { markdown: string }) {
+export function LessonContent({
+  markdown,
+  imageMap,
+}: {
+  markdown: string
+  imageMap?: Record<string, string>
+}) {
   return (
     <article className="prose prose-sm max-w-none dark:prose-invert prose-headings:scroll-mt-20 prose-img:rounded-md prose-img:border">
       <ReactMarkdown
@@ -57,7 +50,7 @@ export function LessonContent({ markdown }: { markdown: string }) {
           img({ src, alt }) {
             return (
               <img
-                src={resolveImageSrc(typeof src === 'string' ? src : undefined)}
+                src={resolveImageSrc(typeof src === 'string' ? src : undefined, imageMap)}
                 alt={alt ?? ''}
                 loading="lazy"
               />

--- a/src/lib/__tests__/image-src.test.ts
+++ b/src/lib/__tests__/image-src.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { resolveImageSrc } from '../image-src'
+
+const RAW = 'https://raw.githubusercontent.com/microsoft/generative-ai-for-beginners/main/'
+
+describe('resolveImageSrc', () => {
+  it('returns undefined for undefined input', () => {
+    expect(resolveImageSrc(undefined)).toBeUndefined()
+  })
+
+  it('passes absolute URLs through unchanged', () => {
+    expect(resolveImageSrc('https://example.com/x.png')).toBe('https://example.com/x.png')
+    expect(resolveImageSrc('data:image/png;base64,iVBORw')).toBe('data:image/png;base64,iVBORw')
+    expect(resolveImageSrc('blob:abc')).toBe('blob:abc')
+  })
+
+  it('rewrites relative paths to GitHub raw URL', () => {
+    const out = resolveImageSrc('../../../translated_images/ko/x.webp')
+    expect(out).toBe(`${RAW}translated_images/ko/x.webp`)
+  })
+
+  it('strips ./ prefix', () => {
+    const out = resolveImageSrc('./images/foo.png')
+    expect(out).toBe(`${RAW}images/foo.png`)
+  })
+
+  it('uses imageMap fallback when key matches', () => {
+    const map = {
+      '../../../translated_images/ko/foo.webp': '01-introduction-to-genai/images/foo.png',
+    }
+    const out = resolveImageSrc('../../../translated_images/ko/foo.webp', map)
+    expect(out).toBe(`${RAW}01-introduction-to-genai/images/foo.png`)
+  })
+
+  it('preserves absolute URLs in imageMap value', () => {
+    const map = {
+      '../../../translated_images/ko/foo.webp': 'https://example.com/foo.png',
+    }
+    const out = resolveImageSrc('../../../translated_images/ko/foo.webp', map)
+    expect(out).toBe('https://example.com/foo.png')
+  })
+
+  it('falls through to default rewriting if imageMap key does not match', () => {
+    const map = { 'other.webp': 'fallback.png' }
+    const out = resolveImageSrc('../../../translated_images/ko/foo.webp', map)
+    expect(out).toBe(`${RAW}translated_images/ko/foo.webp`)
+  })
+})

--- a/src/lib/image-src.ts
+++ b/src/lib/image-src.ts
@@ -1,0 +1,32 @@
+/**
+ * 레슨 본문 마크다운에 포함된 이미지 src 정규화.
+ *
+ * 한국어 README는 `../../../translated_images/ko/<name>.<hash>.webp` 같은
+ * 상대 경로로 이미지를 참조한다. 이를 GitHub raw URL로 변환하되, 빌드 타임에
+ * 폴백 매핑(imageMap)이 있으면 그쪽을 우선 적용해 한국어 번역 이미지가
+ * 누락된 경우 영문 원본으로 자동 대체한다.
+ */
+
+const SOURCE_REPO_RAW_BASE =
+  'https://raw.githubusercontent.com/microsoft/generative-ai-for-beginners/main/'
+
+export function resolveImageSrc(
+  src: string | undefined,
+  imageMap?: Record<string, string>,
+): string | undefined {
+  if (!src) return src
+  if (/^(https?:|data:|blob:)/.test(src)) return src
+
+  // imageMap에 직접 매칭이 있으면 그 결과를 우선 (이미 절대 URL일 수도 있음)
+  if (imageMap && imageMap[src]) {
+    const mapped = imageMap[src]
+    if (/^(https?:|data:|blob:)/.test(mapped)) return mapped
+    return `${SOURCE_REPO_RAW_BASE}${stripRelative(mapped)}`
+  }
+
+  return `${SOURCE_REPO_RAW_BASE}${stripRelative(src)}`
+}
+
+function stripRelative(src: string): string {
+  return src.replace(/^(\.\.\/)+/, '').replace(/^\.\//, '')
+}

--- a/src/routes/lessons/$lessonId.tsx
+++ b/src/routes/lessons/$lessonId.tsx
@@ -65,7 +65,7 @@ function LessonPage() {
               typescriptReference={lesson.typescriptReference}
               typescriptSnippet={spec?.typescriptSnippet}
             />
-            <LessonContent markdown={lesson.contentMarkdown} />
+            <LessonContent markdown={lesson.contentMarkdown} imageMap={lesson.imageMap} />
           </div>
         }
         right={

--- a/src/types/lesson.ts
+++ b/src/types/lesson.ts
@@ -111,6 +111,12 @@ export type LessonContent = {
   typescriptReference: string | null
   /** Whether `lesson-specs/<id>.ts` exists (i.e. interactive panel available). */
   hasVariableSpec: boolean
+  /**
+   * 빌드 타임에 산출된 이미지 폴백 매핑. key는 markdown에서 참조된 원본 src
+   * (예: `../../../translated_images/ko/foo.webp`), value는 폴백 src
+   * (영문 원본 이미지로 대체된 경로). resolveImageSrc가 우선 적용한다.
+   */
+  imageMap?: Record<string, string>
 }
 
 /** Compact entry for the lessons grid — no full markdown body. */

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'node:path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '#': resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary

- 한국어 번역 이미지(`translated_images/ko/<base>.<hash>.<ext>`)가 누락된 경우 빌드 타임에 `<lesson-id>/images/<base>.*` 영문 원본을 자동 폴백으로 매핑
- `resolveImageSrc`를 `src/lib/image-src.ts`로 분리하고 `imageMap` 우선 적용 로직 추가
- minimal vitest 인프라 + 7개 단위 테스트 (이슈 #9에서 본격 확장 예정)
- 누락 이미지는 `pnpm sync-content` 실행 시 콘솔 경고로 보고

## 구조

```
markdown img src
  → imageMap[src]가 있으면 그 값
  → 없으면 GitHub raw URL로 단순 변환
```

## Test plan

- [x] `pnpm sync-content` — 22/22 정상, 누락 이미지 0개 (현재 모든 KO 이미지 존재)
- [x] `pnpm typecheck` — 통과
- [x] `pnpm test` — 7/7 통과
- [x] `pnpm build` — 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)