### PR TITLE
feat(ui): 다크모드 토글 (next-themes) (#2)

### DIFF
--- a/src/components/shared/AppHeader.tsx
+++ b/src/components/shared/AppHeader.tsx
@@ -1,6 +1,8 @@
 import { Link } from '@tanstack/react-router'
 import { Sparkles } from 'lucide-react'
 
+import { ThemeToggle } from './ThemeToggle'
+
 const NAV = [
   { to: '/', label: 'Home' },
   { to: '/lessons', label: 'Lessons' },
@@ -17,19 +19,22 @@ export function AppHeader() {
           <Sparkles className="h-4 w-4" />
           genai-lab
         </Link>
-        <nav className="flex items-center gap-1 text-sm">
-          {NAV.map((item) => (
-            <Link
-              key={item.to}
-              to={item.to}
-              className="rounded-md px-3 py-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-              activeProps={{ className: 'bg-accent text-foreground' }}
-              activeOptions={{ exact: item.to === '/' }}
-            >
-              {item.label}
-            </Link>
-          ))}
-        </nav>
+        <div className="flex items-center gap-2">
+          <nav className="flex items-center gap-1 text-sm">
+            {NAV.map((item) => (
+              <Link
+                key={item.to}
+                to={item.to}
+                className="rounded-md px-3 py-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                activeProps={{ className: 'bg-accent text-foreground' }}
+                activeOptions={{ exact: item.to === '/' }}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <ThemeToggle />
+        </div>
       </div>
     </header>
   )

--- a/src/components/shared/ThemeProvider.tsx
+++ b/src/components/shared/ThemeProvider.tsx
@@ -1,0 +1,12 @@
+/**
+ * next-themes ThemeProvider wrapper. SSR 시 system → resolvedTheme 결정 깜빡임을
+ * 막기 위해 attribute='class' + suppressHydrationWarning을 root에 함께 적용한다.
+ *
+ * (next-themes는 Next.js 전용이 아니라 React 환경에서 동작.)
+ */
+
+import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from 'next-themes'
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}

--- a/src/components/shared/ThemeToggle.tsx
+++ b/src/components/shared/ThemeToggle.tsx
@@ -1,0 +1,60 @@
+/**
+ * sun/moon 아이콘 토글 + system/light/dark 3선택 dropdown. 헤더 우측에 노출.
+ */
+
+import { useEffect, useState } from 'react'
+import { useTheme } from 'next-themes'
+import { Moon, Sun, Monitor } from 'lucide-react'
+
+import { Button } from '#/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '#/components/ui/dropdown-menu'
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  // hydration 경고 방지: 서버에서는 system을 가정, 클라이언트 마운트 후 실제 값 표시
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label="Toggle theme">
+          <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">테마 전환</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          onClick={() => setTheme('light')}
+          aria-current={mounted && theme === 'light' ? 'true' : undefined}
+        >
+          <Sun className="mr-2 h-4 w-4" />
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => setTheme('dark')}
+          aria-current={mounted && theme === 'dark' ? 'true' : undefined}
+        >
+          <Moon className="mr-2 h-4 w-4" />
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => setTheme('system')}
+          aria-current={mounted && theme === 'system' ? 'true' : undefined}
+        >
+          <Monitor className="mr-2 h-4 w-4" />
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { TanStackDevtools } from '@tanstack/react-devtools'
 
 import { AppHeader } from '#/components/shared/AppHeader'
 import { EnvBootstrap } from '#/components/shared/EnvBootstrap'
+import { ThemeProvider } from '#/components/shared/ThemeProvider'
 import { Toaster } from '#/components/ui/sonner'
 import appCss from '../styles.css?url'
 
@@ -33,26 +34,28 @@ export const Route = createRootRoute({
 
 function RootDocument({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>
       <body>
-        <AppHeader />
-        <main>{children}</main>
-        <EnvBootstrap />
-        <Toaster richColors closeButton />
-        <TanStackDevtools
-          config={{
-            position: 'bottom-right',
-          }}
-          plugins={[
-            {
-              name: 'Tanstack Router',
-              render: <TanStackRouterDevtoolsPanel />,
-            },
-          ]}
-        />
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+          <AppHeader />
+          <main>{children}</main>
+          <EnvBootstrap />
+          <Toaster richColors closeButton />
+          <TanStackDevtools
+            config={{
+              position: 'bottom-right',
+            }}
+            plugins={[
+              {
+                name: 'Tanstack Router',
+                render: <TanStackRouterDevtoolsPanel />,
+              },
+            ]}
+          />
+        </ThemeProvider>
         <Scripts />
       </body>
     </html>


### PR DESCRIPTION
## Summary

- `ThemeProvider`(next-themes) 래핑 + `<html suppressHydrationWarning>`으로 SSR 깜빡임 방지
- AppHeader 우측에 sun/moon 아이콘 토글 — Light / Dark / System 3선택 dropdown
- localStorage에 테마 자동 저장
- Shiki는 이미 `themes: { light: 'github-light', dark: 'github-dark' }`로 등록되어 있어 자동 추적

## Test plan

- [x] `pnpm typecheck` — 통과
- [x] `pnpm build` — 통과
- [ ] 헤더 우측에 sun/moon 아이콘 표시 (브라우저 검증 권장)
- [ ] Light → Dark → System 토글 후 새로고침 시 유지
- [ ] 다크 테마에서 Shiki 코드 블록도 다크로 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)