### PR TITLE
feat(ux): 레슨 prev/next 네비 + visited 진도 표시 (#3)

### DIFF
--- a/src/components/lesson/LessonNavigation.tsx
+++ b/src/components/lesson/LessonNavigation.tsx
@@ -1,0 +1,69 @@
+/**
+ * 레슨 페이지 하단의 이전/다음 네비게이션. 22개 레슨을 number 기준 정렬한 후
+ * 현재 레슨의 인접한 항목으로 prefetch=intent 링크를 생성한다.
+ */
+
+import { Link } from '@tanstack/react-router'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+import { getLessonSummaries } from '#/lib/content'
+
+export function LessonNavigation({ currentId }: { currentId: string }) {
+  const summaries = getLessonSummaries().slice().sort((a, b) => a.number - b.number)
+  const idx = summaries.findIndex((s) => s.id === currentId)
+  if (idx === -1) return null
+
+  const prev = idx > 0 ? summaries[idx - 1] : null
+  const next = idx < summaries.length - 1 ? summaries[idx + 1] : null
+
+  return (
+    <nav className="mt-12 flex items-stretch gap-3">
+      <div className="flex-1">
+        {prev ? (
+          <Link
+            to="/lessons/$lessonId"
+            params={{ lessonId: prev.id }}
+            preload="intent"
+            className="flex h-full items-center gap-3 rounded-md border bg-card p-4 transition-colors hover:bg-accent"
+          >
+            <ChevronLeft className="h-5 w-5 text-muted-foreground" />
+            <div className="text-left">
+              <div className="text-xs text-muted-foreground">이전</div>
+              <div className="line-clamp-1 text-sm font-medium">
+                {String(prev.number).padStart(2, '0')} {prev.title}
+              </div>
+            </div>
+          </Link>
+        ) : (
+          <div className="flex h-full items-center gap-3 rounded-md border bg-muted/30 p-4 opacity-50">
+            <ChevronLeft className="h-5 w-5 text-muted-foreground" />
+            <div className="text-xs text-muted-foreground">첫 레슨입니다</div>
+          </div>
+        )}
+      </div>
+      <div className="flex-1">
+        {next ? (
+          <Link
+            to="/lessons/$lessonId"
+            params={{ lessonId: next.id }}
+            preload="intent"
+            className="flex h-full items-center justify-end gap-3 rounded-md border bg-card p-4 transition-colors hover:bg-accent"
+          >
+            <div className="text-right">
+              <div className="text-xs text-muted-foreground">다음</div>
+              <div className="line-clamp-1 text-sm font-medium">
+                {String(next.number).padStart(2, '0')} {next.title}
+              </div>
+            </div>
+            <ChevronRight className="h-5 w-5 text-muted-foreground" />
+          </Link>
+        ) : (
+          <div className="flex h-full items-center justify-end gap-3 rounded-md border bg-muted/30 p-4 opacity-50">
+            <div className="text-xs text-muted-foreground">마지막 레슨입니다</div>
+            <ChevronRight className="h-5 w-5 text-muted-foreground" />
+          </div>
+        )}
+      </div>
+    </nav>
+  )
+}

--- a/src/lib/storage/progress.ts
+++ b/src/lib/storage/progress.ts
@@ -1,0 +1,56 @@
+/**
+ * 학습 진도 저장소 — 방문한 레슨 ID를 localStorage에 영속.
+ * SSR 안전(window 가드).
+ */
+
+const KEY = 'genai-lab:progress:v1'
+
+type Progress = {
+  visitedLessons: string[]
+}
+
+function readProgress(): Progress {
+  if (typeof window === 'undefined') return { visitedLessons: [] }
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return { visitedLessons: [] }
+    const parsed = JSON.parse(raw) as Progress
+    if (!Array.isArray(parsed.visitedLessons)) return { visitedLessons: [] }
+    return parsed
+  } catch {
+    return { visitedLessons: [] }
+  }
+}
+
+function writeProgress(p: Progress): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(KEY, JSON.stringify(p))
+  } catch {
+    // quota / disabled storage — 무시
+  }
+}
+
+export function getVisited(): Set<string> {
+  return new Set(readProgress().visitedLessons)
+}
+
+export function isVisited(lessonId: string): boolean {
+  return getVisited().has(lessonId)
+}
+
+export function markVisited(lessonId: string): void {
+  const p = readProgress()
+  if (p.visitedLessons.includes(lessonId)) return
+  p.visitedLessons.push(lessonId)
+  writeProgress(p)
+}
+
+export function clearProgress(): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.removeItem(KEY)
+  } catch {
+    // ignore
+  }
+}

--- a/src/routes/lessons/$lessonId.tsx
+++ b/src/routes/lessons/$lessonId.tsx
@@ -5,6 +5,7 @@ import { Badge } from '#/components/ui/badge'
 import { Separator } from '#/components/ui/separator'
 import { LessonContent } from '#/components/lesson/LessonContent'
 import { LessonCode } from '#/components/lesson/LessonCode'
+import { LessonNavigation } from '#/components/lesson/LessonNavigation'
 import { SplitPane } from '#/components/lesson/SplitPane'
 import { RunPanel } from '#/components/lesson/RunPanel'
 import { RunHistoryList } from '#/components/lesson/RunHistoryList'
@@ -12,6 +13,7 @@ import { RunHistoryList } from '#/components/lesson/RunHistoryList'
 import { getLesson, getLessonSummary } from '#/lib/content'
 import { getLessonSpec } from '#/lib/lesson-specs'
 import { deleteRun, getRuns } from '#/lib/storage/runs'
+import { markVisited } from '#/lib/storage/progress'
 import type { Run } from '#/types/run'
 
 export const Route = createFileRoute('/lessons/$lessonId')({
@@ -40,6 +42,11 @@ function LessonPage() {
   useEffect(() => {
     refreshRuns()
   }, [refreshRuns])
+
+  // 진도 기록 — 페이지 진입 시 visitedLessons에 추가
+  useEffect(() => {
+    markVisited(lesson.id)
+  }, [lesson.id])
 
   return (
     <div className="container mx-auto max-w-7xl px-6 py-8">
@@ -112,6 +119,8 @@ function LessonPage() {
       />
 
       <Separator className="mt-12" />
+
+      <LessonNavigation currentId={lesson.id} />
     </div>
   )
 }

--- a/src/routes/lessons/index.tsx
+++ b/src/routes/lessons/index.tsx
@@ -1,7 +1,11 @@
+import { useEffect, useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
+import { Check } from 'lucide-react'
+
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '#/components/ui/card'
 import { Badge } from '#/components/ui/badge'
 import { getLessonSummaries } from '#/lib/content'
+import { getVisited } from '#/lib/storage/progress'
 import type { LessonSummary } from '#/types/lesson'
 
 export const Route = createFileRoute('/lessons/')({
@@ -17,6 +21,11 @@ const TYPE_BADGE_VARIANT: Record<LessonSummary['type'], 'default' | 'secondary' 
 
 function LessonsIndex() {
   const { summaries } = Route.useLoaderData()
+  const [visited, setVisited] = useState<Set<string>>(() => new Set())
+
+  useEffect(() => {
+    setVisited(getVisited())
+  }, [])
 
   // 주차별 그룹화 (null인 옵션 레슨은 별도)
   const byWeek: Record<string, LessonSummary[]> = {
@@ -31,10 +40,17 @@ function LessonsIndex() {
     byWeek[key].push(s)
   }
 
+  const visitedCount = summaries.filter((s) => visited.has(s.id)).length
+
   return (
     <div className="container mx-auto max-w-6xl px-6 py-12">
       <header className="mb-10">
-        <h1 className="text-3xl font-bold">레슨 목록</h1>
+        <div className="flex items-baseline justify-between">
+          <h1 className="text-3xl font-bold">레슨 목록</h1>
+          <div className="text-sm text-muted-foreground">
+            진도 <span className="font-mono">{visitedCount}/{summaries.length}</span>
+          </div>
+        </div>
         <p className="mt-2 text-muted-foreground">
           22개 레슨을 권장 학습 주차별로 정렬했습니다. 진도와 무관하게 어떤 레슨부터든 시작할 수 있습니다.
         </p>
@@ -48,7 +64,7 @@ function LessonsIndex() {
               {lessons
                 .sort((a, b) => a.number - b.number)
                 .map((lesson) => (
-                  <LessonCard key={lesson.id} lesson={lesson} />
+                  <LessonCard key={lesson.id} lesson={lesson} visited={visited.has(lesson.id)} />
                 ))}
             </div>
           </section>
@@ -58,7 +74,7 @@ function LessonsIndex() {
   )
 }
 
-function LessonCard({ lesson }: { lesson: LessonSummary }) {
+function LessonCard({ lesson, visited }: { lesson: LessonSummary; visited: boolean }) {
   return (
     <Link
       to="/lessons/$lessonId"
@@ -72,6 +88,15 @@ function LessonCard({ lesson }: { lesson: LessonSummary }) {
               {String(lesson.number).padStart(2, '0')}
             </Badge>
             <div className="flex gap-1">
+              {visited && (
+                <Badge
+                  variant="secondary"
+                  className="bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400"
+                  aria-label="방문함"
+                >
+                  <Check className="h-3 w-3" />
+                </Badge>
+              )}
               <Badge variant={TYPE_BADGE_VARIANT[lesson.type]}>{lesson.type}</Badge>
               {lesson.hasVariableSpec && <Badge variant="secondary">랩</Badge>}
             </div>


### PR DESCRIPTION
## Summary

- `src/lib/storage/progress.ts` — visitedLessons localStorage CRUD (`genai-lab:progress:v1`)
- `LessonNavigation` 컴포넌트 — number 기준 정렬한 prev/next 카드. preload='intent'로 hover 시 미리 로드, 첫/마지막은 비활성화
- 레슨 페이지 진입 시 `markVisited(id)` 호출
- LessonsIndex 헤더에 `진도 N/22` 표시 + LessonCard에 ✓ 배지

## Test plan

- [x] `pnpm typecheck` — 통과
- [x] `pnpm build` — 통과
- [ ] 레슨 페이지 끝에 prev/next 표시 (브라우저 검증)
- [ ] 진입 후 `/lessons`로 가면 ✓ 배지
- [ ] localStorage `genai-lab:progress:v1`에 기록
- [ ] 첫 레슨(00)은 prev 비활성, 마지막(21)은 next 비활성

🤖 Generated with [Claude Code](https://claude.com/claude-code)