### PR TITLE
perf(shiki): fine-grained import으로 번들 8MB→452kB (#6)

### DIFF
--- a/src/components/lesson/CodeBlock.tsx
+++ b/src/components/lesson/CodeBlock.tsx
@@ -1,6 +1,11 @@
 /**
  * Shiki 기반 코드 블록 — 클라이언트 사이드에서 lazy-load 후 syntax highlighting.
- * Python, TypeScript, JavaScript만 등록 (사이즈 최소화).
+ *
+ * fine-grained import로 사용 언어/테마만 번들에 포함시켜 8MB+ 사이즈를 절감.
+ * 새 lang 필요 시: langs 배열에 `import('shiki/langs/<lang>.mjs')` 추가.
+ *
+ * engine: oniguruma의 wasm 대신 JS regex (`engine-javascript`)를 사용해
+ * wasm 파일 의존성을 제거. 일부 정밀도 손실이 있을 수 있으나 학습 코드 범위에서는 충분.
  */
 
 import { useEffect, useState } from 'react'
@@ -13,15 +18,27 @@ let highlighterPromise: Promise<{
 
 async function getHighlighter() {
   if (!highlighterPromise) {
-    highlighterPromise = import('shiki').then(async ({ createHighlighter }) => {
-      const highlighter = await createHighlighter({
-        themes: ['github-dark', 'github-light'],
-        langs: ['python', 'typescript', 'javascript'],
+    highlighterPromise = (async () => {
+      const [{ createHighlighterCore }, { createJavaScriptRegexEngine }] = await Promise.all([
+        import('shiki/core'),
+        import('shiki/engine/javascript'),
+      ])
+      const highlighter = await createHighlighterCore({
+        themes: [
+          import('shiki/themes/github-dark.mjs'),
+          import('shiki/themes/github-light.mjs'),
+        ],
+        langs: [
+          import('shiki/langs/python.mjs'),
+          import('shiki/langs/typescript.mjs'),
+          import('shiki/langs/javascript.mjs'),
+        ],
+        engine: createJavaScriptRegexEngine(),
       })
       return {
         codeToHtml: (code, options) => highlighter.codeToHtml(code, options),
       }
-    })
+    })()
   }
   return highlighterPromise
 }


### PR DESCRIPTION
## Summary

`createHighlighter`(전체 langs/themes 포함) → `createHighlighterCore` + 명시적 dynamic import로 변경. 사용하는 lang/theme만 번들에 포함됨.

엔진은 oniguruma wasm 대신 `createJavaScriptRegexEngine()` 사용 — wasm 의존성 제거.

## 측정 (server/_libs/)

| chunk | before | after | gzip before | gzip after |
|---|---:|---:|---:|---:|
| shikijs__langs.mjs | 8035 kB | 452 kB | 1249 kB | 42 kB |
| shikijs__themes.mjs | 1463 kB | 25 kB | 172 kB | 4 kB |

## 새 lang 추가 방법

`src/components/lesson/CodeBlock.tsx`의 langs 배열에 추가:
```ts
langs: [
  import('shiki/langs/python.mjs'),
  import('shiki/langs/typescript.mjs'),
  import('shiki/langs/javascript.mjs'),
  import('shiki/langs/<your-lang>.mjs'),  // ← 추가
],
```

## Test plan

- [x] `pnpm typecheck` — 통과
- [x] `pnpm build` — 통과 + 번들 사이즈 절감 확인
- [ ] python/typescript/javascript 코드 블록이 시각적으로 동일하게 하이라이트 (브라우저 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)