### PR TITLE
feat(ui): 코드 블록 복사 버튼 + 헤딩 anchor 링크 (#7)

### DIFF
--- a/src/components/lesson/CodeBlock.tsx
+++ b/src/components/lesson/CodeBlock.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useEffect, useState } from 'react'
+import { Check, Copy } from 'lucide-react'
 
 type SupportedLang = 'python' | 'typescript' | 'javascript' | 'plaintext'
 
@@ -28,6 +29,7 @@ async function getHighlighter() {
 
 export function CodeBlock({ code, lang }: { code: string; lang: SupportedLang }) {
   const [html, setHtml] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
 
   useEffect(() => {
     let mounted = true
@@ -53,6 +55,16 @@ export function CodeBlock({ code, lang }: { code: string; lang: SupportedLang })
     }
   }, [code, lang])
 
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch (err) {
+      console.warn('clipboard write failed:', err)
+    }
+  }
+
   if (html === null) {
     return (
       <pre className="overflow-auto rounded-md bg-muted p-4 text-xs">
@@ -62,10 +74,20 @@ export function CodeBlock({ code, lang }: { code: string; lang: SupportedLang })
   }
 
   return (
-    <div
-      className="shiki-block overflow-auto rounded-md text-xs [&_pre]:!m-0 [&_pre]:!bg-muted [&_pre]:!p-4"
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
+    <div className="group relative">
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="absolute right-2 top-2 z-10 rounded-md border bg-background/80 p-1.5 text-muted-foreground opacity-0 backdrop-blur transition-opacity hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
+        aria-label={copied ? '복사됨' : '코드 복사'}
+      >
+        {copied ? <Check className="h-3.5 w-3.5 text-emerald-600" /> : <Copy className="h-3.5 w-3.5" />}
+      </button>
+      <div
+        className="shiki-block overflow-auto rounded-md text-xs [&_pre]:!m-0 [&_pre]:!bg-muted [&_pre]:!p-4"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
   )
 }
 

--- a/src/components/lesson/LessonContent.tsx
+++ b/src/components/lesson/LessonContent.tsx
@@ -1,6 +1,8 @@
+import { Children } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { CodeBlock } from './CodeBlock'
+import { slugify } from '#/lib/slug'
 
 type SupportedLang = 'python' | 'typescript' | 'javascript' | 'plaintext'
 
@@ -77,10 +79,46 @@ export function LessonContent({ markdown }: { markdown: string }) {
               </a>
             )
           },
+          h2: ({ children, ...rest }) => <HeadingWithAnchor level={2} {...rest}>{children}</HeadingWithAnchor>,
+          h3: ({ children, ...rest }) => <HeadingWithAnchor level={3} {...rest}>{children}</HeadingWithAnchor>,
+          h4: ({ children, ...rest }) => <HeadingWithAnchor level={4} {...rest}>{children}</HeadingWithAnchor>,
         }}
       >
         {markdown}
       </ReactMarkdown>
     </article>
+  )
+}
+
+/**
+ * h2/h3/h4에 자동 id 생성 + hover 시 # 앵커 링크 표시.
+ * 한국어 헤딩도 안정적으로 슬러그화한다.
+ */
+function HeadingWithAnchor({
+  level,
+  children,
+}: {
+  level: 2 | 3 | 4
+  children: React.ReactNode
+}) {
+  const text = Children.toArray(children)
+    .map((c) => (typeof c === 'string' ? c : ''))
+    .join('')
+    .trim()
+  const id = text ? slugify(text) : undefined
+  const Tag = `h${level}` as 'h2' | 'h3' | 'h4'
+  return (
+    <Tag id={id} className="group scroll-mt-20">
+      {children}
+      {id && (
+        <a
+          href={`#${id}`}
+          aria-label={`${text} 섹션으로 가는 링크`}
+          className="ml-2 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100"
+        >
+          #
+        </a>
+      )}
+    </Tag>
   )
 }

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,21 @@
+/**
+ * 한국어/영어 헤딩에서 안정적인 anchor id를 생성.
+ *
+ * - 소문자화
+ * - 영숫자/한글/공백/하이픈 외 문자 제거
+ * - 공백을 하이픈으로
+ * - 연속 하이픈 압축
+ * - 양 끝 하이픈 제거
+ * - 빈 결과면 'section'로 폴백
+ */
+export function slugify(text: string): string {
+  const normalized = text
+    .toLowerCase()
+    .normalize('NFKC')
+    .replace(/[^\p{L}\p{N}\s-]/gu, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+  return normalized || 'section'
+}


### PR DESCRIPTION
## Summary

- CodeBlock 우상단에 복사 버튼 (hover/focus opacity)
  - 클릭 시 navigator.clipboard.writeText, 1.5초간 ✓ 아이콘 표시
- LessonContent의 h2/h3/h4에 자동 id + hover 시 # 앵커 링크
- `src/lib/slug.ts` — 한국어/영어 헤딩 모두 안정적으로 슬러그화 (유니코드 letter/number 보존)

## Test plan

- [x] `pnpm typecheck` — 통과
- [x] `pnpm build` — 통과
- [ ] CodeBlock에 hover 시 복사 아이콘 표시 (브라우저 검증)
- [ ] 클릭 시 클립보드에 복사 + ✓ 표시
- [ ] h2/h3 hover 시 # 아이콘
- [ ] # 클릭 시 URL `/lessons/...#section-id`로 변경 + 스크롤
- [ ] 한국어 헤딩 (예: "## 학습 목표") 안정적 ID 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)