### PR TITLE
feat(reliability): React Error Boundary로 RunPanel 크래시 격리 (#8)

### DIFF
--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -1,0 +1,70 @@
+/**
+ * 자체 구현 React Error Boundary.
+ * 자식이 렌더 단계에서 throw하면 fallback을 렌더하고 reset 버튼으로 다시 시도.
+ *
+ * 비동기 throw(예: 이벤트 핸들러나 setTimeout 안에서 발생한 예외)는 React Error
+ * Boundary가 잡지 못한다 — 그쪽은 try/catch로 직접 핸들링해야 한다.
+ */
+
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { AlertTriangle, RefreshCw } from 'lucide-react'
+
+import { Button } from '#/components/ui/button'
+
+type Props = {
+  children: ReactNode
+  /** fallback render. 미지정 시 기본 빨간 박스 사용 */
+  fallback?: (props: { error: Error; reset: () => void }) => ReactNode
+  /** 에러 발생 시 추가 콜백 (로깅 등) */
+  onError?: (error: Error, info: ErrorInfo) => void
+}
+
+type State = {
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // dev에서 디버깅 가능하도록 콘솔 출력 + onError 콜백 호출
+    console.error('[ErrorBoundary]', error, info)
+    this.props.onError?.(error, info)
+  }
+
+  reset = () => {
+    this.setState({ error: null })
+  }
+
+  render() {
+    const { error } = this.state
+    if (error) {
+      if (this.props.fallback) {
+        return this.props.fallback({ error, reset: this.reset })
+      }
+      return <DefaultFallback error={error} reset={this.reset} />
+    }
+    return this.props.children
+  }
+}
+
+function DefaultFallback({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="rounded-md border border-destructive/30 bg-destructive/5 p-4 text-sm">
+      <div className="flex items-center gap-2 font-medium text-destructive">
+        <AlertTriangle className="h-4 w-4" />
+        예상치 못한 오류가 발생했습니다.
+      </div>
+      <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded bg-background/50 p-2 font-mono text-xs text-muted-foreground">
+        {error.message || String(error)}
+      </pre>
+      <Button onClick={reset} variant="outline" size="sm" className="mt-3">
+        <RefreshCw className="mr-1.5 h-3 w-3" /> 다시 시도
+      </Button>
+    </div>
+  )
+}

--- a/src/routes/lessons/$lessonId.tsx
+++ b/src/routes/lessons/$lessonId.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, notFound } from '@tanstack/react-router'
 
 import { Badge } from '#/components/ui/badge'
 import { Separator } from '#/components/ui/separator'
+import { ErrorBoundary } from '#/components/shared/ErrorBoundary'
 import { LessonContent } from '#/components/lesson/LessonContent'
 import { LessonCode } from '#/components/lesson/LessonCode'
 import { SplitPane } from '#/components/lesson/SplitPane'
@@ -76,12 +77,14 @@ function LessonPage() {
                 변수를 조정하고 Run을 누르면 LLM이 실시간으로 응답합니다. 결과는 자동으로 history에 저장됩니다.
               </p>
               {spec ? (
-                <RunPanel
-                  spec={spec}
-                  lessonId={lesson.id}
-                  initialValues={restoreInputs}
-                  onRunComplete={refreshRuns}
-                />
+                <ErrorBoundary>
+                  <RunPanel
+                    spec={spec}
+                    lessonId={lesson.id}
+                    initialValues={restoreInputs}
+                    onRunComplete={refreshRuns}
+                  />
+                </ErrorBoundary>
               ) : (
                 <div className="rounded-md bg-muted p-4 text-sm">
                   <p className="font-medium">이 레슨은 개념 학습용입니다.</p>
@@ -95,16 +98,18 @@ function LessonPage() {
 
             {spec && (
               <div className="rounded-lg border bg-card p-5">
-                <RunHistoryList
-                  runs={runs}
-                  onRestore={(run) => {
-                    setRestoreInputs(run.inputs)
-                  }}
-                  onDelete={(id) => {
-                    deleteRun(id)
-                    refreshRuns()
-                  }}
-                />
+                <ErrorBoundary>
+                  <RunHistoryList
+                    runs={runs}
+                    onRestore={(run) => {
+                      setRestoreInputs(run.inputs)
+                    }}
+                    onDelete={(id) => {
+                      deleteRun(id)
+                      refreshRuns()
+                    }}
+                  />
+                </ErrorBoundary>
               </div>
             )}
           </div>

--- a/src/routes/playground.tsx
+++ b/src/routes/playground.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { PlaygroundPanel } from '#/components/playground/PlaygroundPanel'
+import { ErrorBoundary } from '#/components/shared/ErrorBoundary'
 
 export const Route = createFileRoute('/playground')({ component: Playground })
 
@@ -12,7 +13,9 @@ function Playground() {
           레슨과 무관한 자유 실험실. 모델/프롬프트/파라미터를 자유롭게 조합하고 결과를 비교하세요.
         </p>
       </header>
-      <PlaygroundPanel />
+      <ErrorBoundary>
+        <PlaygroundPanel />
+      </ErrorBoundary>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- `src/components/shared/ErrorBoundary.tsx` — 자체 클래스 컴포넌트
  - fallback prop 또는 기본 빨간 박스 + ✓ 다시 시도 버튼
  - `componentDidCatch`에서 `console.error`로 dev 디버깅 가능
  - 외부 패키지(react-error-boundary) 추가 없이 자체 구현
- `lessons/$lessonId.tsx` — RunPanel과 RunHistoryList 각각 wrap
- `playground.tsx` — PlaygroundPanel wrap

## Test plan

- [x] `pnpm typecheck` — 통과
- [x] `pnpm build` — 통과
- [ ] 의도적 throw로 RunPanel 크래시 → 패널만 빨간 박스, 좌측 본문 정상 (브라우저 검증)
- [ ] reset 버튼 클릭 시 패널 다시 렌더
- [ ] error는 console.error로 기록

🤖 Generated with [Claude Code](https://claude.com/claude-code)