### PR TITLE
test: Vitest 인프라 + 핵심 lib 15개 테스트 (#9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
     "sync-content": "tsx scripts/sync-content.ts",
     "smoke-test": "tsx scripts/smoke-test.ts"

--- a/src/lib/llm/__tests__/cosine-similarity.test.ts
+++ b/src/lib/llm/__tests__/cosine-similarity.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { cosineSimilarity } from '../github-models-embedding'
+
+describe('cosineSimilarity', () => {
+  it('returns 1 for identical vectors', () => {
+    expect(cosineSimilarity([1, 0, 0], [1, 0, 0])).toBeCloseTo(1, 6)
+    expect(cosineSimilarity([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])).toBeCloseTo(1, 6)
+  })
+
+  it('returns 0 for orthogonal vectors', () => {
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0, 6)
+    expect(cosineSimilarity([1, 0, 0], [0, 1, 0])).toBeCloseTo(0, 6)
+  })
+
+  it('returns -1 for opposite vectors', () => {
+    expect(cosineSimilarity([1, 0], [-1, 0])).toBeCloseTo(-1, 6)
+  })
+
+  it('returns 0 when one vector is zero (avoid div-by-zero)', () => {
+    expect(cosineSimilarity([0, 0, 0], [1, 2, 3])).toBe(0)
+    expect(cosineSimilarity([1, 2, 3], [0, 0, 0])).toBe(0)
+  })
+
+  it('throws on dimension mismatch', () => {
+    expect(() => cosineSimilarity([1, 2], [1, 2, 3])).toThrow(/차원 불일치/)
+  })
+
+  it('handles non-unit-length vectors correctly', () => {
+    // [3, 4]와 [3, 4]는 동일 방향 → 1
+    expect(cosineSimilarity([3, 4], [3, 4])).toBeCloseTo(1, 6)
+    // [3, 4]와 [6, 8]은 같은 방향(스칼라 배수) → 1
+    expect(cosineSimilarity([3, 4], [6, 8])).toBeCloseTo(1, 6)
+  })
+})

--- a/src/lib/llm/__tests__/stream-chat.test.ts
+++ b/src/lib/llm/__tests__/stream-chat.test.ts
@@ -1,0 +1,132 @@
+/**
+ * streamChat 통합 테스트 — fetch를 mock해서 SSE 청크 파싱과 tool_calls
+ * 누적 로직을 검증. 직전 픽스(streaming tool_calls index별 누적)의 회귀를 막는다.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mockSseResponse } from '../../../../vitest.setup'
+import { streamChat } from '../index'
+
+const originalFetch = globalThis.fetch
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn()
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('streamChat', () => {
+  it('accumulates text deltas into final output', async () => {
+    const sseChunks = [
+      JSON.stringify({
+        id: '1',
+        model: 'gpt-4o-mini',
+        choices: [{ index: 0, delta: { content: 'Hello, ' }, finish_reason: null }],
+      }),
+      JSON.stringify({
+        id: '1',
+        model: 'gpt-4o-mini',
+        choices: [{ index: 0, delta: { content: 'world!' }, finish_reason: null }],
+      }),
+      JSON.stringify({
+        id: '1',
+        model: 'gpt-4o-mini',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+      }),
+    ]
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockSseResponse(sseChunks))
+
+    const result = await streamChat(
+      {
+        provider: 'github-models',
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: 'hi' }],
+      },
+      { apiKey: 'test', onChunk: () => {} },
+    )
+
+    expect(result.output).toBe('Hello, world!')
+    expect(result.usage.prompt_tokens).toBe(5)
+    expect(result.usage.completion_tokens).toBe(3)
+    expect(result.toolCalls).toBeUndefined()
+  })
+
+  it('accumulates streaming tool_calls fragments by index (regression for #pr0864e14)', async () => {
+    // SSE에서 tool_call의 id, name, arguments는 여러 청크에 걸쳐 fragments로 도착.
+    // index를 키로 누적해야 함.
+    const sseChunks = [
+      JSON.stringify({
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                { index: 0, id: 'call_abc', type: 'function', function: { name: 'add' } },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      }),
+      JSON.stringify({
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [{ index: 0, function: { arguments: '{"a":' } }],
+            },
+            finish_reason: null,
+          },
+        ],
+      }),
+      JSON.stringify({
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [{ index: 0, function: { arguments: '1,"b":2}' } }],
+            },
+            finish_reason: null,
+          },
+        ],
+      }),
+      JSON.stringify({
+        choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }],
+      }),
+    ]
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockSseResponse(sseChunks))
+
+    const result = await streamChat(
+      {
+        provider: 'github-models',
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: '1+2' }],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'add',
+              description: 'sum of two numbers',
+              parameters: {
+                type: 'object',
+                properties: { a: { type: 'number' }, b: { type: 'number' } },
+              },
+            },
+          },
+        ],
+      },
+      { apiKey: 'test', onChunk: () => {} },
+    )
+
+    expect(result.toolCalls).toBeDefined()
+    expect(result.toolCalls).toHaveLength(1)
+    expect(result.toolCalls?.[0]).toMatchObject({
+      id: 'call_abc',
+      name: 'add',
+      arguments: '{"a":1,"b":2}',
+    })
+  })
+})

--- a/src/lib/storage/__tests__/runs.test.ts
+++ b/src/lib/storage/__tests__/runs.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { saveRun, getRuns, getRunById, deleteRun, clearRuns } from '../runs'
+
+const baseRun = {
+  lessonId: 'test-lesson' as const,
+  inputs: { a: 1 },
+  output: 'hello',
+  metadata: {
+    provider: 'github-models' as const,
+    model: 'gpt-4o-mini',
+    latencyMs: 100,
+    promptTokens: 5,
+    completionTokens: 10,
+  },
+}
+
+describe('storage/runs', () => {
+  it('saveRun assigns id+timestamp and returns the finalized run', () => {
+    const r = saveRun(baseRun)
+    expect(r.id).toBeTruthy()
+    expect(r.timestamp).toBeGreaterThan(0)
+    expect(r.output).toBe('hello')
+  })
+
+  it('getRuns returns saved runs in newest-first order', () => {
+    saveRun({ ...baseRun, output: 'first' })
+    saveRun({ ...baseRun, output: 'second' })
+    const runs = getRuns()
+    expect(runs).toHaveLength(2)
+    expect(runs[0].output).toBe('second')
+    expect(runs[1].output).toBe('first')
+  })
+
+  it('getRuns filters by lessonId', () => {
+    saveRun({ ...baseRun, lessonId: 'lesson-a', output: 'A' })
+    saveRun({ ...baseRun, lessonId: 'lesson-b', output: 'B' })
+    saveRun({ ...baseRun, lessonId: 'lesson-a', output: 'A2' })
+    expect(getRuns({ lessonId: 'lesson-a' })).toHaveLength(2)
+    expect(getRuns({ lessonId: 'lesson-b' })).toHaveLength(1)
+  })
+
+  it('getRunById finds by id', () => {
+    const saved = saveRun(baseRun)
+    const found = getRunById(saved.id)
+    expect(found?.id).toBe(saved.id)
+    expect(getRunById('nonexistent')).toBeUndefined()
+  })
+
+  it('deleteRun removes by id', () => {
+    const a = saveRun({ ...baseRun, output: 'A' })
+    const b = saveRun({ ...baseRun, output: 'B' })
+    deleteRun(a.id)
+    const remaining = getRuns()
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0].id).toBe(b.id)
+  })
+
+  it('clearRuns({lessonId}) clears only that lesson', () => {
+    saveRun({ ...baseRun, lessonId: 'lesson-a' })
+    saveRun({ ...baseRun, lessonId: 'lesson-b' })
+    clearRuns({ lessonId: 'lesson-a' })
+    expect(getRuns({ lessonId: 'lesson-a' })).toHaveLength(0)
+    expect(getRuns({ lessonId: 'lesson-b' })).toHaveLength(1)
+  })
+
+  it('clearRuns() with no filter clears all', () => {
+    saveRun(baseRun)
+    saveRun(baseRun)
+    clearRuns()
+    expect(getRuns()).toHaveLength(0)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'node:path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '#': resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'scripts/**/*.test.ts'],
+  },
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,28 @@
+import { beforeEach } from 'vitest'
+
+// 각 테스트 사이에 localStorage 초기화 — storage 테스트 격리
+beforeEach(() => {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.clear()
+  }
+})
+
+/**
+ * SSE 스트림 응답 객체를 mock하는 헬퍼 — `data: <chunk>\n\n` 포맷으로 인코딩.
+ * 마지막에 `data: [DONE]\n\n`을 자동 추가.
+ */
+export function mockSseResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder()
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(encoder.encode(`data: ${c}\n\n`))
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+      controller.close()
+    },
+  })
+  return new Response(body, {
+    status: 200,
+    statusText: 'OK',
+    headers: { 'Content-Type': 'text/event-stream' },
+  })
+}


### PR DESCRIPTION
## Summary

Vitest 인프라(jsdom, setup) + 핵심 lib에 대한 첫 단위 테스트 15개. CI 파이프라인(#5)과 함께 회귀 방지망 구축.

## 추가된 테스트

| File | Tests | 커버 |
|---|---:|---|
| `cosine-similarity.test.ts` | 6 | identical=1, orthogonal=0, opposite=-1, zero handling, dim mismatch, scalar invariance |
| `stream-chat.test.ts` | 2 | 텍스트 청크 누적, **streaming tool_calls fragments index별 누적 회귀 방지** (직전 픽스 영역) |
| `runs.test.ts` | 7 | saveRun, getRuns 정렬/필터, getRunById, deleteRun, clearRuns |

## 인프라

- `vitest.config.ts`: jsdom + alias + setupFiles
- `vitest.setup.ts`: 매 테스트마다 localStorage clear + `mockSseResponse(chunks)` 헬퍼
- `package.json`: `test:watch`, `test:coverage` 스크립트 추가

## 향후 확장 (별도 PR)

- runAgent loop / maxIterations
- runRag retrieval+chat 합성
- storage/settings, storage/progress
- sync-content의 cleanupMarkdown / notebookToPython (export 필요)
- UI 컴포넌트 (@testing-library/react)

## Test plan

- [x] `pnpm test` — 15 tests passed
- [x] `pnpm typecheck` — 통과
- [ ] CI 파이프라인에서 자동 실행 (#5 머지 후 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)