### PR TITLE
feat(storage): Run history export/import (#11)

### DIFF
--- a/src/lib/storage/runs.ts
+++ b/src/lib/storage/runs.ts
@@ -72,3 +72,79 @@ export function clearRuns(filter?: { lessonId?: string }): void {
   const all = readAll().filter((r) => r.lessonId !== filter.lessonId)
   writeAll(all)
 }
+
+/**
+ * 모든 Run을 JSON 문자열로 직렬화. 파일 다운로드용.
+ */
+export function exportRunsAsJson(): string {
+  return JSON.stringify(readAll(), null, 2)
+}
+
+export type ImportSummary = {
+  imported: number
+  skipped: number
+  total: number
+}
+
+/**
+ * JSON 문자열을 파싱해 기존 runs와 병합. id가 같으면 timestamp가 새로운 것을 유지.
+ * 잘못된 형식이면 throw.
+ */
+export function importRunsFromJson(json: string): ImportSummary {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(json)
+  } catch {
+    throw new Error('JSON 파싱에 실패했습니다. 파일 형식을 확인하세요.')
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error('Run history는 배열이어야 합니다.')
+  }
+  const incoming: Run[] = []
+  for (const item of parsed) {
+    if (!isValidRun(item)) {
+      throw new Error('일부 항목이 Run 스키마를 만족하지 않습니다.')
+    }
+    incoming.push(item)
+  }
+
+  const existing = readAll()
+  const byId = new Map(existing.map((r) => [r.id, r]))
+  let imported = 0
+  let skipped = 0
+  for (const r of incoming) {
+    const dup = byId.get(r.id)
+    if (dup) {
+      // timestamp가 더 새로운 쪽을 유지
+      if (r.timestamp > dup.timestamp) {
+        byId.set(r.id, r)
+        imported += 1
+      } else {
+        skipped += 1
+      }
+    } else {
+      byId.set(r.id, r)
+      imported += 1
+    }
+  }
+
+  // timestamp 내림차순 정렬 후 MAX_RUNS로 자름
+  const merged = [...byId.values()].sort((a, b) => b.timestamp - a.timestamp).slice(0, MAX_RUNS)
+  writeAll(merged)
+  return { imported, skipped, total: incoming.length }
+}
+
+function isValidRun(x: unknown): x is Run {
+  if (!x || typeof x !== 'object') return false
+  const r = x as Record<string, unknown>
+  return (
+    typeof r.id === 'string' &&
+    typeof r.timestamp === 'number' &&
+    typeof r.lessonId === 'string' &&
+    typeof r.output === 'string' &&
+    !!r.inputs &&
+    typeof r.inputs === 'object' &&
+    !!r.metadata &&
+    typeof r.metadata === 'object'
+  )
+}

--- a/src/routes/history.tsx
+++ b/src/routes/history.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { GitCompare, Trash2 } from 'lucide-react'
+import { Download, GitCompare, Trash2, Upload } from 'lucide-react'
 import { toast } from 'sonner'
 
 import { Badge } from '#/components/ui/badge'
@@ -17,7 +17,13 @@ import {
 import { CompareDialog } from '#/components/lesson/CompareDialog'
 
 import { getLessonSummaries } from '#/lib/content'
-import { clearRuns, deleteRun, getRuns } from '#/lib/storage/runs'
+import {
+  clearRuns,
+  deleteRun,
+  exportRunsAsJson,
+  getRuns,
+  importRunsFromJson,
+} from '#/lib/storage/runs'
 import type { Run } from '#/types/run'
 
 export const Route = createFileRoute('/history')({
@@ -31,6 +37,7 @@ function History() {
   const [filter, setFilter] = useState<string>('all')
   const [selected, setSelected] = useState<string[]>([])
   const [compareOpen, setCompareOpen] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const refresh = useCallback(() => {
     setAllRuns(getRuns())
@@ -39,6 +46,41 @@ function History() {
   useEffect(() => {
     refresh()
   }, [refresh])
+
+  const handleExport = () => {
+    const json = exportRunsAsJson()
+    const blob = new Blob([json], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `genai-lab-runs-${new Date().toISOString().slice(0, 10)}.json`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+    toast.success(`${allRuns.length}개의 Run을 내보냈습니다.`)
+  }
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    e.target.value = '' // 같은 파일을 다시 선택할 수 있도록 reset
+    if (!file) return
+    try {
+      const text = await file.text()
+      const summary = importRunsFromJson(text)
+      refresh()
+      toast.success(
+        `${summary.imported}개 추가됨${summary.skipped > 0 ? ` · ${summary.skipped}개 skip` : ''}`,
+      )
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      toast.error('Import 실패', { description: message })
+    }
+  }
 
   const filtered = useMemo(() => {
     if (filter === 'all') return allRuns
@@ -99,23 +141,42 @@ function History() {
           <GitCompare className="mr-1.5 h-4 w-4" /> 비교 ({selected.length}/2)
         </Button>
 
-        {filtered.length > 0 && (
+        <div className="ml-auto flex items-center gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json,.json"
+            className="hidden"
+            onChange={handleImportFile}
+          />
+          <Button size="sm" variant="outline" onClick={handleImportClick}>
+            <Upload className="mr-1.5 h-4 w-4" /> Import
+          </Button>
           <Button
             size="sm"
             variant="outline"
-            className="ml-auto"
-            onClick={() => {
-              if (!confirm(`${filter === 'all' ? '모든' : '필터된'} Run 기록을 삭제하시겠습니까?`)) return
-              if (filter === 'all') clearRuns()
-              else clearRuns({ lessonId: filter })
-              refresh()
-              setSelected([])
-              toast.success('기록이 삭제되었습니다.')
-            }}
+            onClick={handleExport}
+            disabled={allRuns.length === 0}
           >
-            <Trash2 className="mr-1.5 h-4 w-4" /> 모두 삭제
+            <Download className="mr-1.5 h-4 w-4" /> Export
           </Button>
-        )}
+          {filtered.length > 0 && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                if (!confirm(`${filter === 'all' ? '모든' : '필터된'} Run 기록을 삭제하시겠습니까?`)) return
+                if (filter === 'all') clearRuns()
+                else clearRuns({ lessonId: filter })
+                refresh()
+                setSelected([])
+                toast.success('기록이 삭제되었습니다.')
+              }}
+            >
+              <Trash2 className="mr-1.5 h-4 w-4" /> 모두 삭제
+            </Button>
+          )}
+        </div>
       </div>
 
       {filtered.length === 0 ? (


### PR DESCRIPTION
## Summary

- `exportRunsAsJson()` / `importRunsFromJson(json)` 헬퍼
- /history 페이지에 Export / Import 버튼
- 중복 ID 정책: timestamp가 새로운 쪽 유지, 그 외는 skip
- 잘못된 형식은 throw → 기존 기록 보존 + toast 에러
- 병합 후 MAX_RUNS(200) 초과분은 가장 오래된 것부터 자름

## Test plan

- [x] `pnpm typecheck` — 통과
- [x] `pnpm build` — 통과
- [ ] /history에서 Export 클릭 → `genai-lab-runs-YYYY-MM-DD.json` 다운로드 (브라우저 검증)
- [ ] 다른 브라우저/시크릿에서 Import → 기록 복원
- [ ] 잘못된 JSON 업로드 → 기존 기록 유지 + toast 에러

🤖 Generated with [Claude Code](https://claude.com/claude-code)