### PR TITLE
fix(ui): Shiki dual-theme이 manual .dark 토글에 반응하도록 수정

### DIFF
--- a/src/components/lesson/CodeBlock.tsx
+++ b/src/components/lesson/CodeBlock.tsx
@@ -13,8 +13,19 @@ import { Check, Copy } from 'lucide-react'
 
 type SupportedLang = 'python' | 'typescript' | 'javascript' | 'plaintext'
 
+type CodeToHtmlOptions = {
+  lang: string
+  themes: { light: string; dark: string }
+  /**
+   * false면 default color span을 만들지 않고 --shiki-light/--shiki-dark CSS 변수만
+   * 출력. 우리는 next-themes 의 .dark 클래스로 수동 토글하므로 prefers-color-scheme
+   * 기반 자동 전환이 어긋난다 — CSS 변수로 직접 제어.
+   */
+  defaultColor: false
+}
+
 let highlighterPromise: Promise<{
-  codeToHtml: (code: string, options: { lang: string; themes: { light: string; dark: string } }) => string
+  codeToHtml: (code: string, options: CodeToHtmlOptions) => string
 }> | null = null
 
 async function getHighlighter() {
@@ -60,6 +71,7 @@ export function CodeBlock({ code, lang }: { code: string; lang: SupportedLang })
         const out = highlighter.codeToHtml(code, {
           lang,
           themes: { light: 'github-light', dark: 'github-dark' },
+          defaultColor: false,
         })
         setHtml(out)
       })
@@ -101,7 +113,7 @@ export function CodeBlock({ code, lang }: { code: string; lang: SupportedLang })
         {copied ? <Check className="h-3.5 w-3.5 text-emerald-600" /> : <Copy className="h-3.5 w-3.5" />}
       </button>
       <div
-        className="shiki-block overflow-auto rounded-md text-xs [&_pre]:!m-0 [&_pre]:!bg-muted [&_pre]:!p-4"
+        className="shiki-block overflow-auto rounded-md text-xs [&_pre]:!m-0 [&_pre]:!p-4"
         dangerouslySetInnerHTML={{ __html: html }}
       />
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -145,3 +145,21 @@ body {
     @apply font-sans;
   }
 }
+
+/*
+ * Shiki dual-theme: defaultColor=false로 출력된 결과의 --shiki-light/--shiki-dark
+ * CSS 변수를 .dark 클래스에 따라 수동 적용 (next-themes가 .dark 클래스를 토글).
+ *
+ * Shiki의 기본 동작은 prefers-color-scheme 미디어 쿼리지만, 사용자 수동 테마
+ * 토글과 어긋나서 다크 배경에 라이트 테마 색이 노출되어 가독성이 깨짐.
+ */
+.shiki,
+.shiki span {
+  color: var(--shiki-light);
+  background-color: var(--shiki-light-bg);
+}
+.dark .shiki,
+.dark .shiki span {
+  color: var(--shiki-dark);
+  background-color: var(--shiki-dark-bg);
+}


### PR DESCRIPTION
## Summary

다크모드에서 코드 블록 가독성이 매우 낮은 문제 수정.

## 원인

Shiki의 dual-theme 기본 동작은 `@media (prefers-color-scheme: dark)`로 색을 전환하는데, 우리는 next-themes가 `.dark` 클래스를 수동 토글합니다. 시스템이 라이트인 상태에서 사용자가 앱을 다크모드로 토글하면, Shiki는 여전히 라이트 테마 색(예: 회색 텍스트)을 출력하고 배경만 다크가 되어 거의 안 보이는 상태가 됩니다.

추가로 `[&_pre]:!bg-muted` Tailwind 오버라이드가 Shiki 배경을 무력화하면서 같은 효과를 라이트 모드에서도 부분적으로 일으켰습니다.

## 해결

- `CodeBlock.tsx`: `codeToHtml`에 `defaultColor: false`를 전달 → Shiki가 inline default color 대신 `--shiki-light` / `--shiki-dark` CSS 변수만 출력
- `styles.css`: `.shiki`(라이트) / `.dark .shiki`(다크) 각각이 해당 변수를 사용하도록 명시
- `CodeBlock.tsx`: `[&_pre]:!bg-muted` 강제 오버라이드 제거

## Test plan

- [x] `pnpm typecheck` — 통과
- [x] `pnpm test` — 22/22 통과
- [ ] 다크모드 토글 → 코드 블록의 변수/문자열/주석 색이 모두 또렷이 보임 (브라우저 검증)
- [ ] 라이트모드에서도 회귀 없이 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)