### PR TITLE
fix(ui): 코드 색 테마 → Night Owl (다크모드 가독성)

### DIFF
--- a/src/components/lesson/CodeBlock.tsx
+++ b/src/components/lesson/CodeBlock.tsx
@@ -6,6 +6,10 @@
  *
  * engine: oniguruma의 wasm 대신 JS regex (`engine-javascript`)를 사용해
  * wasm 파일 의존성을 제거. 일부 정밀도 손실이 있을 수 있으나 학습 코드 범위에서는 충분.
+ *
+ * 테마 선택: Night Owl은 색맹/저조도 환경 접근성을 명시적으로 고려한 테마로,
+ * github-dark 대비 다크모드에서 코드 가독성이 더 좋다 (배경 #011627 / 텍스트 #d6deeb).
+ * 라이트 모드는 동일 시리즈의 night-owl-light로 일관성 유지.
  */
 
 import { useEffect, useState } from 'react'
@@ -37,8 +41,8 @@ async function getHighlighter() {
       ])
       const highlighter = await createHighlighterCore({
         themes: [
-          import('shiki/themes/github-dark.mjs'),
-          import('shiki/themes/github-light.mjs'),
+          import('shiki/themes/night-owl.mjs'),
+          import('shiki/themes/night-owl-light.mjs'),
         ],
         langs: [
           import('shiki/langs/python.mjs'),
@@ -70,7 +74,7 @@ export function CodeBlock({ code, lang }: { code: string; lang: SupportedLang })
         if (!mounted) return
         const out = highlighter.codeToHtml(code, {
           lang,
-          themes: { light: 'github-light', dark: 'github-dark' },
+          themes: { light: 'night-owl-light', dark: 'night-owl' },
           defaultColor: false,
         })
         setHtml(out)


### PR DESCRIPTION
## Summary

[웹 리서치](https://github.com/sdras/night-owl-vscode-theme) 결과 다크모드 코드 가독성 1순위는 **Night Owl** — 색맹/저조도 환경 접근성을 명시적으로 고려해 설계된 테마. GitHub Dark는 회색 톤(코멘트/문자열)이 다크 배경에서 묻히는 문제가 있음.

## 변경

| | Before | After |
|---|---|---|
| Light theme | `github-light` | `night-owl-light` |
| Dark theme | `github-dark` | `night-owl` |
| 다크 배경 | `#0d1117` (거의 흑) | `#011627` (딥 블루, halation ↓) |
| 다크 텍스트 | `#e6edf3` (회색) | `#d6deeb` (오프화이트) |
| 다크 키워드 | `#ff7b72` | `#c792ea` (보라) — 채도 분명 |
| 다크 문자열 | `#a5d6ff` | `#ecc48d` (오렌지) — 키워드와 명확히 구분 |

## 번들

`shikijs__themes.mjs`: 25 kB → 61 kB (gzip 4 → 7 kB). 이전 fine-grained import(8MB→452kB) 대비 무시할 수준.

## 참고 자료

- WCAG 다크모드 기준: 텍스트 4.5:1, 비-텍스트 3:1
- 순흑(#000) 대신 딥블루/딥그레이로 halation 회피
- Night Owl은 색맹 안전 색상

## Test plan

- [x] `pnpm typecheck` / `pnpm test 22/22` / `pnpm build`
- [ ] 다크모드에서 변수/문자열/주석/키워드 모두 또렷이 보임 (브라우저 검증)
- [ ] 라이트모드에서도 night-owl-light가 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)